### PR TITLE
Changed Rc to Arc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ mod timestamp;
 use std::{
     collections::BTreeSet,
     fmt::{self, Display, Formatter, Write},
-    rc::Rc,
+    sync::Arc,
     str::FromStr,
 };
 
@@ -89,7 +89,7 @@ fn check_line<S: AsRef<str>>(line: S) -> Result<(), LyricsError> {
 pub struct Lyrics {
     /// Metadata about this lyrics.
     pub metadata: BTreeSet<IDTag>,
-    timed_lines:  Vec<(TimeTag, Rc<str>)>,
+    timed_lines:  Vec<(TimeTag, Arc<str>)>,
     lines:        Vec<String>,
 }
 
@@ -189,7 +189,7 @@ impl Lyrics {
         if len == 0 {
             self.lines.push(line);
         } else {
-            let line: Rc<str> = line.into();
+            let line: Arc<str> = line.into();
 
             let len_dec = len - 1;
 
@@ -208,7 +208,7 @@ impl Lyrics {
     }
 
     #[inline]
-    unsafe fn add_timed_line_unchecked(&mut self, time_tag: TimeTag, line: Rc<str>) {
+    unsafe fn add_timed_line_unchecked(&mut self, time_tag: TimeTag, line: Arc<str>) {
         let mut insert_index = self.timed_lines.len();
 
         while insert_index > 0 {
@@ -233,7 +233,7 @@ impl Lyrics {
     }
 
     #[inline]
-    pub fn get_timed_lines(&self) -> &[(TimeTag, Rc<str>)] {
+    pub fn get_timed_lines(&self) -> &[(TimeTag, Arc<str>)] {
         &self.timed_lines
     }
 
@@ -243,7 +243,7 @@ impl Lyrics {
     }
 
     #[inline]
-    pub fn remove_timed_line(&mut self, index: usize) -> (TimeTag, Rc<str>) {
+    pub fn remove_timed_line(&mut self, index: usize) -> (TimeTag, Arc<str>) {
         self.timed_lines.remove(index)
     }
 


### PR DESCRIPTION
Changed the type of the timed_lines field in the Lyrics struct to use Arc instead of Rc to make Lyrics implement Send and Sync.